### PR TITLE
Ignore keyup events when focused on a textarea or text input element.

### DIFF
--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
@@ -5,6 +5,7 @@
         ["g i", () => { document.location.href = "/admin/"; }],
         ["g l", () => showDialog("model-list-dialog")]
     ]);
+    const inputTextFieldTypes = ['text', 'email', 'tel', 'url'];
     
     function registerDeclarativeShortcuts() {
         const elements = document.querySelectorAll('[data-keyboard-shortcut]');
@@ -20,8 +21,9 @@
     }
 
     function is_focused_text_field() {
-      let active = document.activeElement;
-      return (active.nodeName == 'INPUT' && active.type == 'text') || active.nodeName == 'TEXTAREA'
+      let tag = document.activeElement.nodeName,
+          type = document.activeElement.nodeName;
+      return tag === 'TEXTAREA' || (tag === 'INPUT' && (!type || inputTextFieldTypes.includes(type)));
     }
 
     function removePreviousKey(key) {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
@@ -5,7 +5,7 @@
         ["g i", () => { document.location.href = "/admin/"; }],
         ["g l", () => showDialog("model-list-dialog")]
     ]);
-
+    
     function registerDeclarativeShortcuts() {
         const elements = document.querySelectorAll('[data-keyboard-shortcut]');
         for (const element of elements) {
@@ -17,6 +17,11 @@
 
     function isApple() {
         return (navigator.platform.indexOf("Mac") === 0 || navigator.platform === "iPhone");
+    }
+
+    function is_focused_text_field() {
+      let active = document.activeElement;
+      return (active.nodeName == 'INPUT' && active.type == 'text') || active.nodeName == 'TEXTAREA'
     }
 
     function removePreviousKey(key) {
@@ -47,6 +52,7 @@
     }
 
     function handleKeyUp(event) {
+        if (is_focused_text_field()) return;
         const shortcut = previousKey ? `${previousKey} ${event.key}` : event.key;
         if (shortcutFunctions.has(shortcut)) {
             shortcutFunctions.get(shortcut)();

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
@@ -1,11 +1,19 @@
 'use strict';
+
+const inputTextFieldTypes = ['text', 'email', 'tel', 'url'];
+
+function isFocusedTextField() {
+    let tag = document.activeElement.nodeName,
+        type = document.activeElement.type;
+    return tag === 'TEXTAREA' || (tag === 'INPUT' && (!type || inputTextFieldTypes.includes(type)));
+}
+
 {
     let previousKey = undefined;
     const shortcutFunctions = new Map([
         ["g i", () => { document.location.href = "/admin/"; }],
         ["g l", () => showDialog("model-list-dialog")]
     ]);
-    const inputTextFieldTypes = ['text', 'email', 'tel', 'url'];
 
     function registerDeclarativeShortcuts() {
         const elements = document.querySelectorAll('[data-keyboard-shortcut]');
@@ -18,12 +26,6 @@
 
     function isApple() {
         return (navigator.platform.indexOf("Mac") === 0 || navigator.platform === "iPhone");
-    }
-
-    function is_focused_text_field() {
-      let tag = document.activeElement.nodeName,
-          type = document.activeElement.nodeName;
-      return tag === 'TEXTAREA' || (tag === 'INPUT' && (!type || inputTextFieldTypes.includes(type)));
     }
 
     function removePreviousKey(key) {
@@ -54,7 +56,7 @@
     }
 
     function handleKeyUp(event) {
-        if (is_focused_text_field()) return;
+        if (isFocusedTextField()) return;
         const shortcut = previousKey ? `${previousKey} ${event.key}` : event.key;
         if (shortcutFunctions.has(shortcut)) {
             shortcutFunctions.get(shortcut)();

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts.js
@@ -6,7 +6,7 @@
         ["g l", () => showDialog("model-list-dialog")]
     ]);
     const inputTextFieldTypes = ['text', 'email', 'tel', 'url'];
-    
+
     function registerDeclarativeShortcuts() {
         const elements = document.querySelectorAll('[data-keyboard-shortcut]');
         for (const element of elements) {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changeform.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changeform.js
@@ -13,7 +13,6 @@
     }
 
     function handleKeyUp(event) {
-      if (is_focused_text_field()) return;
         switch (event.code) {
         case "KeyS":
             if (event.altKey) {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changeform.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changeform.js
@@ -13,6 +13,7 @@
     }
 
     function handleKeyUp(event) {
+      if (is_focused_text_field()) return;
         switch (event.code) {
         case "KeyS":
             if (event.altKey) {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -43,8 +43,8 @@
     }
 
     function handleKeyUp(event) {
-      if (is_focused_text_field()) return;
-      switch (event.code) {
+        if (is_focused_text_field()) return;
+        switch (event.code) {
         case "KeyK":
             focusPreviousCheckbox();
             break;

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -43,7 +43,7 @@
     }
 
     function handleKeyUp(event) {
-        if (is_focused_text_field()) return;
+        if (isFocusedTextField()) return;
         switch (event.code) {
         case "KeyK":
             focusPreviousCheckbox();

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -43,7 +43,8 @@
     }
 
     function handleKeyUp(event) {
-        switch (event.code) {
+      if (is_focused_text_field()) return;
+      switch (event.code) {
         case "KeyK":
             focusPreviousCheckbox();
             break;

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_delete_confirmation.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_delete_confirmation.js
@@ -17,7 +17,8 @@
     }
 
     function handleKeyUp(event) {
-        switch (event.code) {
+      if (is_focused_text_field()) return;
+      switch (event.code) {
         case "KeyY":
             if (event.altKey) {
                 confirmDeletion();

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_delete_confirmation.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_delete_confirmation.js
@@ -17,7 +17,6 @@
     }
 
     function handleKeyUp(event) {
-      if (is_focused_text_field()) return;
       switch (event.code) {
         case "KeyY":
             if (event.altKey) {


### PR DESCRIPTION
Fixes #13 in a pretty trivial way - just returns immediately when the focused element is a text field/area.  