### PR TITLE
use django admin color variables so dark mode works

### DIFF
--- a/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
+++ b/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
@@ -14,6 +14,8 @@ kbd {
 }
 
 dialog {
+  background-color: var(--darkened-bg);
+  color: var(--body-fg);
   min-width: 20em;
   padding: 1em;
   height: 50vh;

--- a/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
+++ b/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
@@ -1,11 +1,11 @@
 kbd {
-  background-color: #eee;
+  background-color: var(--body-bg);
   border-radius: 3px;
-  border: 1px solid #b4b4b4;
+  border: 1px solid var(--border-color);
   box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.2),
     0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-  color: #333;
+  color: var(--body-fg);
   display: inline-block;
   font-size: 1em;
   line-height: 1;
@@ -30,7 +30,8 @@ dialog {
   }
 
   h3 {
-    background: #eee;
+    background: var(--header-bg);
+    color: var(--header-color);
     margin: 0;
     padding: 0.5em 1em;
   }
@@ -55,7 +56,7 @@ dialog {
       column-gap: 1em;
       display: flex;
       justify-content: space-between;
-      border-top: 1px solid #000;
+      border-top: 1px solid var(--border-color);
       padding: 1em;
     }
   }


### PR DESCRIPTION
fixes #8
![Screenshot 2024-06-10 105139](https://github.com/knyghty/django-admin-keyboard-shortcuts/assets/768592/abb5884d-337b-40f5-8048-69626895f369)
