### PR TITLE
Fixed #16 -  Implemented vimkeys checkbox navigation rollover

### DIFF
--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -1,7 +1,7 @@
 'use strict';
 {
     let checkboxes = null;
-    let currentCheckbox = null;
+    let currentCheckboxIndex = null;
 
     function setUpShortcuts() {
         checkboxes = document.querySelectorAll("#action-toggle, .action-select");
@@ -11,30 +11,28 @@
         if (!checkboxes.length) {
             return;
         }
-        if (!currentCheckbox) {
-            currentCheckbox = checkboxes.length - 1;
+        if (currentCheckboxIndex === null) {
+            currentCheckboxIndex = checkboxes.length - 1;
         } else {
-            currentCheckbox = checkboxes[Array.prototype.indexOf.call(checkboxes, currentCheckbox) - 1];
+            currentCheckboxIndex = (currentCheckboxIndex - 1 + checkboxes.length) % checkboxes.length;
         }
-        currentCheckbox.focus();
+        checkboxes[currentCheckboxIndex].focus();
     }
 
     function focusNextCheckbox() {
         if (!checkboxes.length) {
             return;
         }
-        if (!currentCheckbox) {
-            currentCheckbox = checkboxes[0];
+        if (currentCheckboxIndex === null) {
+            currentCheckboxIndex = 0;
         } else {
-            currentCheckbox = checkboxes[Array.prototype.indexOf.call(checkboxes, currentCheckbox) + 1];
+            currentCheckboxIndex = (currentCheckboxIndex + 1) % checkboxes.length;
         }
-        currentCheckbox.focus();
+        checkboxes[currentCheckboxIndex].focus();
     }
 
     function selectCheckbox() {
-        if (currentCheckbox) {
-            currentCheckbox.click();
-        }
+        checkboxes[currentCheckboxIndex].click();
     }
 
     function selectActionsSelect() {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -32,7 +32,9 @@
     }
 
     function selectCheckbox() {
-        checkboxes[currentCheckboxIndex].click();
+        if (currentCheckboxIndex !== null) {
+                checkboxes[currentCheckboxIndex].click();
+        }
     }
 
     function selectActionsSelect() {

--- a/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
+++ b/django_admin_keyboard_shortcuts/static/admin/js/shortcuts_changelist.js
@@ -11,10 +11,10 @@
         if (!checkboxes.length) {
             return;
         }
-        if (currentCheckboxIndex === null) {
+        if (currentCheckboxIndex === null || currentCheckboxIndex === 0) {
             currentCheckboxIndex = checkboxes.length - 1;
         } else {
-            currentCheckboxIndex = (currentCheckboxIndex - 1 + checkboxes.length) % checkboxes.length;
+            currentCheckboxIndex = currentCheckboxIndex - 1;
         }
         checkboxes[currentCheckboxIndex].focus();
     }
@@ -23,10 +23,10 @@
         if (!checkboxes.length) {
             return;
         }
-        if (currentCheckboxIndex === null) {
+        if (currentCheckboxIndex === null || currentCheckboxIndex === checkboxes.length - 1) {
             currentCheckboxIndex = 0;
         } else {
-            currentCheckboxIndex = (currentCheckboxIndex + 1) % checkboxes.length;
+            currentCheckboxIndex = currentCheckboxIndex + 1;
         }
         checkboxes[currentCheckboxIndex].focus();
     }


### PR DESCRIPTION
~~Prevents overflow by keeping track of the checkbox selection index and limiting its value between minimum and maximum.~~
Rolls over the checkbox selection by keeping track of the checkbox selection index and incrementing/decrementing via modular arithmetic.

Fixed #16 