### PR TITLE
Fix #2 - Flatten CSS

### DIFF
--- a/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
+++ b/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
@@ -20,48 +20,48 @@ dialog {
   padding: 1em;
   height: 50vh;
   width: 40vw;
+}
 
-  .dialog-heading {
-    align-items: center;
-    display: flex;
-    justify-content: space-between;
+.dialog-heading {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
 
-    h2 {
-      margin: 0;
-    }
-  }
+.dialog-heading h2 {
+  margin: 0;
+}
 
-  h3 {
-    background: var(--header-bg);
-    color: var(--header-color);
-    margin: 0;
-    padding: 0.5em 1em;
-  }
+dialog h3 {
+  background: var(--header-bg);
+  color: var(--header-color);
+  margin: 0;
+  padding: 0.5em 1em;
+}
 
-  button {
-    background: inherit;
-    cursor: pointer;
-    border: 0;
-    font-size: 1.5em;
-    padding: 0;
-    width: 30px;
-    height: 30px;
-  }
+dialog button {
+  background: inherit;
+  cursor: pointer;
+  border: 0;
+  font-size: 1.5em;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+}
 
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+dialog ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
-    li {
-      align-items: center;
-      column-gap: 1em;
-      display: flex;
-      justify-content: space-between;
-      border-top: 1px solid var(--border-color);
-      padding: 1em;
-    }
-  }
+dialog ul li {
+  align-items: center;
+  column-gap: 1em;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--border-color);
+  padding: 1em;
 }
 
 #model-list-dialog-search {


### PR DESCRIPTION
Replace nested CSS in `static/admin/css/shortcut.css` with traditional structured CSS.

Before changing CSS:

<img width="954" alt="before" src="https://github.com/user-attachments/assets/eca72a77-9044-4666-a719-42e7f02f3222" />

After changing CSS:

<img width="954" alt="after" src="https://github.com/user-attachments/assets/09095876-5486-4c7c-b8cb-c75498887c1c" />

It seems that the modification doesn't change the visual effect.