### PR TITLE
Fixed #11 - Add a "keyboard-shortcut-dialog" CSS class

### DIFF
--- a/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
+++ b/django_admin_keyboard_shortcuts/static/admin/css/shortcuts.css
@@ -13,7 +13,7 @@ kbd {
   white-space: nowrap;
 }
 
-dialog {
+.keyboard-shortcut-dialog {
   background-color: var(--darkened-bg);
   color: var(--body-fg);
   min-width: 20em;

--- a/django_admin_keyboard_shortcuts/templates/admin/base.html
+++ b/django_admin_keyboard_shortcuts/templates/admin/base.html
@@ -15,7 +15,7 @@
   <button id="open-shortcuts" data-keyboard-shortcut="?">
     <kbd>?</kbd>
   </button>
-  <dialog id="model-list-dialog">
+  <dialog class="keyboard-shortcut-dialog" id="model-list-dialog">
     <div class="dialog-heading">
       <h2>{% translate "Models" %}</h2>
       <form method="dialog">
@@ -50,7 +50,7 @@
       {% endfor %}
     </div>
   </dialog>
-  <dialog id="shortcuts-dialog">
+  <dialog class="keyboard-shortcut-dialog" id="shortcuts-dialog">
     <div class="dialog-heading">
       <h2>{% translate "Keyboard shortcuts" %}</h2>
       <form method="dialog">


### PR DESCRIPTION
Replaced `dialog` style with `.keyboard-shortcut-dialog` in css and made corresponding modifications in js